### PR TITLE
Remove BurntSushi

### DIFF
--- a/boot/generation_validator.go
+++ b/boot/generation_validator.go
@@ -18,14 +18,15 @@ package boot
 
 import (
 	"fmt"
+	"io/ioutil"
 	"os"
 	"regexp"
 	"time"
 
-	"github.com/BurntSushi/toml"
 	"github.com/Masterminds/semver/v3"
 	"github.com/heroku/color"
 	"github.com/paketo-buildpacks/libpak/bard"
+	"github.com/pelletier/go-toml"
 )
 
 const DatePattern = "2006-01-02"
@@ -92,9 +93,13 @@ type GenerationValidator struct {
 }
 
 func NewGenerationValidator(path string) (GenerationValidator, error) {
-	var p Projects
+	b, err := ioutil.ReadFile(path)
+	if err != nil && !os.IsNotExist(err) {
+		return GenerationValidator{}, fmt.Errorf("unable to read %s\n%w", path, err)
+	}
 
-	if _, err := toml.DecodeFile(path, &p); err != nil && !os.IsNotExist(err) {
+	var p Projects
+	if err := toml.Unmarshal(b, &p); err != nil {
 		return GenerationValidator{}, fmt.Errorf("unable to decode %s\n%w", path, err)
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/paketo-buildpacks/spring-boot
 go 1.15
 
 require (
-	github.com/BurntSushi/toml v0.3.1
 	github.com/Masterminds/semver/v3 v3.1.0
 	github.com/buildpacks/libcnb v1.18.0
 	github.com/heroku/color v0.0.6
@@ -11,6 +10,7 @@ require (
 	github.com/onsi/gomega v1.10.3
 	github.com/paketo-buildpacks/libjvm v1.24.0
 	github.com/paketo-buildpacks/libpak v1.48.0
+	github.com/pelletier/go-toml v1.8.1
 	github.com/sclevine/spec v1.4.0
 	gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776
 )

--- a/go.sum
+++ b/go.sum
@@ -5,8 +5,9 @@ github.com/Masterminds/semver/v3 v3.1.0/go.mod h1:VPu/7SZ7ePZ3QOrcuXROw5FAcLl4a0
 github.com/buildpacks/libcnb v1.18.0 h1:Q7I+HjQ1Cq02/AqhTOrzecuNESip9xE2axckxnymYLQ=
 github.com/buildpacks/libcnb v1.18.0/go.mod h1:yzAQd//jyUXVx6Z/F0cKk/hrl49QZq1OE/hP5+/ZPuQ=
 github.com/creack/pty v1.1.11/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
-github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
@@ -41,7 +42,6 @@ github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+W
 github.com/onsi/ginkgo v1.12.1 h1:mFwc4LvZ0xpSvDZ3E+k8Yte0hLOMxXUlP+yXtJqkYfQ=
 github.com/onsi/ginkgo v1.12.1/go.mod h1:zj2OWP4+oCPe1qIXoGWkgMRwljMUYCdkwsT2108oapk=
 github.com/onsi/gomega v1.7.1/go.mod h1:XdKZgCCFLUoM/7CFJVPcG8C1xQ1AJ0vpAezJrB7JYyY=
-github.com/onsi/gomega v1.10.2 h1:aY/nuoWlKJud2J6U0E3NWsjlg+0GtwXxgEqthRdzlcs=
 github.com/onsi/gomega v1.10.2/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1ybHNo=
 github.com/onsi/gomega v1.10.3 h1:gph6h/qe9GSUw1NhH1gp+qb+h8rXD8Cy60Z32Qw3ELA=
 github.com/onsi/gomega v1.10.3/go.mod h1:V9xEwhxec5O8UDM77eCW8vLymOMltsqPVYWrpDsH8xc=
@@ -51,6 +51,8 @@ github.com/paketo-buildpacks/libpak v1.48.0 h1:8p+hyjZbbWExag6WxyCnNJrEOmjvbK6LB
 github.com/paketo-buildpacks/libpak v1.48.0/go.mod h1:gx1On0u2+Ihyy4sw3nwnawsb+Mkby1FBB/7DQReXdxs=
 github.com/pavel-v-chernykh/keystore-go v2.1.0+incompatible h1:Jd6xfriVlJ6hWPvYOE0Ni0QWcNTLRehfGPFxr3eSL80=
 github.com/pavel-v-chernykh/keystore-go v2.1.0+incompatible/go.mod h1:xlUlxe/2ItGlQyMTstqeDv9r3U4obH7xYd26TbDQutY=
+github.com/pelletier/go-toml v1.8.1 h1:1Nf83orprkJyknT6h7zbuEGUEjcyVlCxSUGTENmNCRM=
+github.com/pelletier/go-toml v1.8.1/go.mod h1:T2/BmBdy8dvIRq1a/8aqjN41wvWlN4lrapLU/GW4pbc=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/sclevine/spec v1.4.0 h1:z/Q9idDcay5m5irkZ28M7PtQM4aOISzOpj4bUPkDee8=


### PR DESCRIPTION
Previously, this project used the BurntSushi TOML library.  This library is now unmaintained and shouldn't be used for long term projects.  This change migrates the project onto an alternative TOML library.