### PR TITLE
Omit empty configuration metadata fields

### DIFF
--- a/boot/configuration_metadata.go
+++ b/boot/configuration_metadata.go
@@ -37,7 +37,7 @@ type Group struct {
 }
 
 type Deprecation struct {
-	Level       string `json:"level"`
+	Level       string `json:"level,omitempty"`
 	Reason      string `json:"reason,omitempty"`
 	Replacement string `json:"replacement,omitempty"`
 }
@@ -58,7 +58,7 @@ type ValueHint struct {
 
 type ValueProvider struct {
 	Name       string                 `json:"name"`
-	Parameters map[string]interface{} `json:"parameters"`
+	Parameters map[string]interface{} `json:"parameters,omitempty"`
 }
 
 type Hint struct {


### PR DESCRIPTION
Signed-off-by: Scott Frederick <sfrederick@vmware.com>

## Summary
When copying configuration metadata from a `META-INF/spring-configuration-metadata.json` file to the `org.springframework.boot.spring-configuration-metadata.json` label, a few fields are written to the output as empty or with a value `null` instead of being omitted when they are missing from the input. This change makes the output more consistent with the input by omitting these fields from the output when they are empty. 


