### PR TITLE
Test was failing because version used in the test was too old

### DIFF
--- a/boot/generation_validator_test.go
+++ b/boot/generation_validator_test.go
@@ -80,9 +80,11 @@ func testGenerationValidator(t *testing.T, context spec.G, it spec.S) {
 	})
 
 	it("logs open source warning", func() {
-		Expect(gv.Validate("spring-boot", "2.1.0.RELEASE")).NotTo(HaveOccurred())
+		// implementation of Validate uses `time.Now()` and will eventually need to be updated
+		// `boot/testdata/test-spring-generations.toml has the defined generations for this test
+		Expect(gv.Validate("spring-boot", "2.2.0.RELEASE")).NotTo(HaveOccurred())
 		Expect(b.String()).To(Equal(fmt.Sprintf("  %s\n", color.New(color.FgYellow, color.Bold, color.Faint).Sprint(
-			"This application uses Spring Boot 2.1.0.RELEASE. Open Source updates for 2.1.x ended on 2019-10-01."))))
+			"This application uses Spring Boot 2.2.0.RELEASE. Open Source updates for 2.2.x ended on 2020-10-01."))))
 	})
 
 }


### PR DESCRIPTION
## Summary

Bumped version used in test and added a comment for future reference.

## Use Cases

Unit tests were failing: https://github.com/paketo-buildpacks/spring-boot/pull/75/checks?check_run_id=2325325578

## Checklist

* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [X] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [N/A] I have added an integration test, if necessary.
* [X] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
