### PR TITLE
Reduce the size of labels on images where Spring Boot buildpack participates

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ This buildpack will participate if all the following conditions are met
 The buildpack will do the following:
 
 * Contributes Spring Boot version to `org.springframework.boot.version` image label
-* Contributes Spring Boot configuration metadata to `org.springframework.boot.spring-configuration-metadata.json` image label
 * If `<APPLICATION_ROOT>/META-INF/dataflow-configuration-metadata.properties` exists
+  * Contributes Spring Boot configuration metadata to `org.springframework.boot.spring-configuration-metadata.json` image label
   * Contributes Spring Cloud Data Flow configuration metadata to `org.springframework.cloud.dataflow.spring-configuration-metadata.json` image label
 * Contributes `Implementation-Title` manifest entry to `org.opencontainers.image.title` image label
 * Contributes `Implementation-version` manifest entry to `org.opencontainers.image.version` image label

--- a/boot/build.go
+++ b/boot/build.go
@@ -210,8 +210,11 @@ func labels(context libcnb.BuildContext, manifest *properties.Properties) ([]lib
 }
 
 func configurationMetadataLabels(appDir string, manifest *properties.Properties) ([]libcnb.Label, error) {
-	var labels []libcnb.Label
+	if ok, err := DataFlowConfigurationExists(appDir); !ok || err != nil {
+		return []libcnb.Label{}, err
+	}
 
+	var labels []libcnb.Label
 	md, err := NewConfigurationMetadataFromPath(appDir)
 	if err != nil {
 		return nil, fmt.Errorf("unable to read configuration metadata from %s\n%w", appDir, err)

--- a/boot/build_test.go
+++ b/boot/build_test.go
@@ -87,7 +87,7 @@ Spring-Boot-Lib: BOOT-INF/lib
 		Expect(result.Labels).To(ContainElement(libcnb.Label{Key: "org.springframework.boot.version", Value: "1.1.1"}))
 	})
 
-	it("contributes org.springframework.boot.spring-configuration-metadata.json label", func() {
+	it("skips org.springframework.boot.spring-configuration-metadata.json label when DataFlow is not present", func() {
 		Expect(ioutil.WriteFile(filepath.Join(ctx.Application.Path, "META-INF", "MANIFEST.MF"), []byte(`
 Spring-Boot-Version: 1.1.1
 Spring-Boot-Classes: BOOT-INF/classes
@@ -99,7 +99,7 @@ Spring-Boot-Lib: BOOT-INF/lib
 		result, err := build.Build(ctx)
 		Expect(err).NotTo(HaveOccurred())
 
-		Expect(result.Labels).To(ContainElement(libcnb.Label{
+		Expect(result.Labels).ToNot(ContainElement(libcnb.Label{
 			Key:   "org.springframework.boot.spring-configuration-metadata.json",
 			Value: `{"groups":[{"name":"alpha"}]}`,
 		}))

--- a/boot/configuration_metadata.go
+++ b/boot/configuration_metadata.go
@@ -122,6 +122,17 @@ func NewConfigurationMetadataFromJAR(jar string) (ConfigurationMetadata, error) 
 	return c, nil
 }
 
+func DataFlowConfigurationExists(path string) (bool, error) {
+	_, err := os.Stat(filepath.Join(path, "META-INF", "dataflow-configuration-metadata.properties"))
+	if err != nil && os.IsNotExist(err) {
+		return false, nil
+	}
+	if err != nil && !os.IsNotExist(err) {
+		return false, err
+	}
+	return true, nil
+}
+
 func NewDataFlowConfigurationMetadata(path string, metadata ConfigurationMetadata) (ConfigurationMetadata, error) {
 	file := filepath.Join(path, "META-INF", "dataflow-configuration-metadata.properties")
 	b, err := ioutil.ReadFile(file)

--- a/boot/generation_validator_test.go
+++ b/boot/generation_validator_test.go
@@ -69,7 +69,7 @@ func testGenerationValidator(t *testing.T, context spec.G, it spec.S) {
 	})
 
 	it("does not log warning", func() {
-		Expect(gv.Validate("spring-boot", "2.3.0.RELEASE")).NotTo(HaveOccurred())
+		Expect(gv.Validate("spring-boot", "2.4.0.RELEASE")).NotTo(HaveOccurred())
 		Expect(b.Len()).To(BeZero())
 	})
 

--- a/boot/web_application_type_test.go
+++ b/boot/web_application_type_test.go
@@ -19,6 +19,7 @@ package boot_test
 import (
 	"io/ioutil"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/buildpacks/libcnb"
@@ -42,10 +43,17 @@ func testWebApplicationType(t *testing.T, context spec.G, it spec.S) {
 		ctx.Layers.Path, err = ioutil.TempDir("", "web-application-type")
 		Expect(err).NotTo(HaveOccurred())
 
+		Expect(ioutil.WriteFile(filepath.Join(ctx.Layers.Path, "app-file-1"), []byte("some contents"), 0644)).To(Succeed())
+		Expect(ioutil.WriteFile(filepath.Join(ctx.Layers.Path, "app-file-2"), []byte("some more contents"), 0400)).To(Succeed())
+
 		wr := boot.WebApplicationTypeResolver{Classes: map[string]interface{}{}}
 
 		w, err = boot.NewWebApplicationType(ctx.Layers.Path, wr)
 		Expect(err).NotTo(HaveOccurred())
+
+		val, ok := w.LayerContributor.ExpectedMetadata.(map[string]interface{})
+		Expect(ok).To(BeTrue())
+		Expect(val["files"]).To(HaveLen(64))
 	})
 
 	it.After(func() {


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary

1. Instead of storing file information in the expected layer metadata, take a hash of all that data and store the hash. It was not necessary to store the actual files and there should be no observable difference in behavior with this approach.
2. Change the `org.springframework.boot.spring-configuration-metadata.json` label to only be added for Spring DataFlow applications. This label could not be completely dropped as Spring Dataflow's UI is making use of this metadata. If this continues to pose a problem, we'll need to discuss options with the Spring Dataflow team.

## Use Cases

Resolves #80.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
