### PR TITLE
add build configuration env "BP_SPRING_CLOUD_BINDINGS_ENABLED"

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ The buildpack will do the following:
 ## Configuration
 | Environment Variable | Description
 | -------------------- | -----------
+| `$BP_SPRING_CLOUD_BINDINGS_ENABLED` | Whether to contribute Spring Boot cloud bindings support.  Defaults to y.
 | `$BPL_SPRING_CLOUD_BINDINGS_ENABLED` | Whether to auto-configure Spring Boot environment properties from bindings.  Defaults to y.
 
 ## Bindings

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -32,6 +32,12 @@ api = "0.7"
   pre-package = "scripts/build.sh"
 
   [[metadata.configurations]]
+    name        = "BP_SPRING_CLOUD_BINDINGS_ENABLED"
+    description = "whether to contribute Spring Boot cloud bindings support"
+    default     = "true"
+    build       = true
+
+  [[metadata.configurations]]
     default = "true"
     description = "whether to auto-configure Spring Boot environment properties from bindings"
     launch = true


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
Consider BP_SPRING_CLOUD_BINDINGS_ENABLED at build time
#118 

## Use Cases
Spring cloud bindings is based on spring boot 2.3.

When building applications based on spring boot 2.2, provide an environment variable (BP_SPRING_CLOUD_BINDINGS_ENABLED) to exclude spring cloud bindings to exclude spring cloud bindings.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
