### PR TITLE
Polishing around new Spring Cloud Bindings changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,9 @@ The buildpack will do the following:
 ## Configuration
 | Environment Variable | Description
 | -------------------- | -----------
-| `$BP_SPRING_CLOUD_BINDINGS_ENABLED` | Whether to contribute Spring Boot cloud bindings support.  Defaults to y.
-| `$BPL_SPRING_CLOUD_BINDINGS_ENABLED` | Whether to auto-configure Spring Boot environment properties from bindings.  Defaults to y.
+| `$BP_SPRING_CLOUD_BINDINGS_DISABLED` | Whether to contribute Spring Boot cloud bindings support.  Defaults to y.
+| `$BPL_SPRING_CLOUD_BINDINGS_DISABLED` | Whether to auto-configure Spring Boot environment properties from bindings.  Defaults to y.
+| `$BPL_SPRING_CLOUD_BINDINGS_ENABLED` | Deprecated in favour of `$BPL_SPRING_CLOUD_BINDINGS_DISABLED`. Whether to auto-configure Spring Boot environment properties from bindings.  Defaults to y.
 
 ## Bindings
 The buildpack optionally accepts the following bindings:

--- a/boot/build_test.go
+++ b/boot/build_test.go
@@ -317,13 +317,13 @@ Spring-Boot-Lib: BOOT-INF/lib
 		})
 	})
 
-	context("set BP_SPRING_CLOUD_BINDINGS_ENABLED to false", func() {
+	context("set BP_SPRING_CLOUD_BINDINGS_DISABLED to true", func() {
 		it.Before(func() {
-			Expect(os.Setenv("BP_SPRING_CLOUD_BINDINGS_ENABLED", "false")).To(Succeed())
+			Expect(os.Setenv("BP_SPRING_CLOUD_BINDINGS_DISABLED", "true")).To(Succeed())
 		})
 
 		it.After(func() {
-			Expect(os.Unsetenv(("BP_SPRING_CLOUD_BINDINGS_ENABLED"))).To(Succeed())
+			Expect(os.Unsetenv(("BP_SPRING_CLOUD_BINDINGS_DISABLED"))).To(Succeed())
 		})
 
 		it("contributes to the result for API 0.7+", func() {

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -32,16 +32,22 @@ api = "0.7"
   pre-package = "scripts/build.sh"
 
   [[metadata.configurations]]
-    name        = "BP_SPRING_CLOUD_BINDINGS_ENABLED"
+    name        = "BP_SPRING_CLOUD_BINDINGS_DISABLED"
     description = "whether to contribute Spring Boot cloud bindings support"
-    default     = "true"
+    default     = "false"
     build       = true
 
   [[metadata.configurations]]
     default = "true"
-    description = "whether to auto-configure Spring Boot environment properties from bindings"
+    description = "Deprecated - whether to auto-configure Spring Boot environment properties from bindings"
     launch = true
     name = "BPL_SPRING_CLOUD_BINDINGS_ENABLED"
+
+  [[metadata.configurations]]
+    default = "false"
+    description = "whether to auto-configure Spring Boot environment properties from bindings"
+    launch = true
+    name = "BPL_SPRING_CLOUD_BINDINGS_DISABLED"
 
   [[metadata.dependencies]]
     cpes = ["cpe:2.3:a:vmware:spring_cloud_bindings:1.8.1:*:*:*:*:*:*:*"]

--- a/helper/spring_cloud_bindings.go
+++ b/helper/spring_cloud_bindings.go
@@ -22,6 +22,10 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/paketo-buildpacks/libpak/sherpa"
+
+	"github.com/heroku/color"
+
 	"github.com/paketo-buildpacks/libpak/bard"
 )
 
@@ -33,14 +37,16 @@ func (s SpringCloudBindings) Execute() (map[string]string, error) {
 	var err error
 
 	enabled := true
-	if s, ok := os.LookupEnv("BPL_SPRING_CLOUD_BINDINGS_ENABLED"); ok {
-		enabled, err = strconv.ParseBool(s)
+	if val, ok := os.LookupEnv("BPL_SPRING_CLOUD_BINDINGS_ENABLED"); ok {
+		s.Logger.Infof(color.YellowString("WARNING: BPL_SPRING_CLOUD_BINDINGS_ENABLED is deprecated, support will be removed in a coming release. Use BPL_SPRING_CLOUD_BINDINGS_DISABLED instead"))
+		enabled, err = strconv.ParseBool(val)
 		if err != nil {
 			return nil, fmt.Errorf("unable to parse $BPL_SPRING_CLOUD_BINDINGS_ENABLED\n%w", err)
 		}
 	}
 
-	if !enabled {
+	// Switching from "BPL_SPRING_CLOUD_BINDINGS_ENABLED" to "BPL_SPRING_CLOUD_BINDINGS_DISABLED" which defaults to 'false' to follow convention
+	if sherpa.ResolveBool("BPL_SPRING_CLOUD_BINDINGS_DISABLED") || !enabled {
 		return nil, nil
 	}
 

--- a/helper/spring_cloud_bindings_test.go
+++ b/helper/spring_cloud_bindings_test.go
@@ -47,6 +47,20 @@ func testSpringCloudBindings(t *testing.T, context spec.G, it spec.S) {
 		})
 	})
 
+	context("$BPL_SPRING_CLOUD_BINDINGS_DISABLED", func() {
+		it.Before(func() {
+			Expect(os.Setenv("BPL_SPRING_CLOUD_BINDINGS_DISABLED", "true")).To(Succeed())
+		})
+
+		it.After(func() {
+			Expect(os.Unsetenv("BPL_SPRING_CLOUD_BINDINGS_DISABLED")).To(Succeed())
+		})
+
+		it("returns if $BPL_SPRING_CLOUD_BINDINGS_DISABLED is set to true", func() {
+			Expect(s.Execute()).To(BeNil())
+		})
+	})
+
 	it("contributes configuration", func() {
 		Expect(s.Execute()).To(Equal(map[string]string{
 			"JAVA_TOOL_OPTIONS": "-Dorg.springframework.cloud.bindings.boot.enable=true",


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary

This changes the recently added `BP_SPRING_CLOUD_BINDINGS_ENABLED` build-time config option to `BP_SPRING_CLOUD_BINDINGS_DISABLED` to follow the Paketo convention of the default being `false` for such options.

In line with this change, the existing runtime config option `BPL_SPRING_CLOUD_BINDINGS_ENABLED` will be deprecated with this PR and support for `BPL_SPRING_CLOUD_BINDINGS_DISABLED` has been added. This switches the default from `true` to `false` as bindings remain enabled by default at runtime. A warning notes this deprecation if the option is explicitly set.

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
