### PR TITLE
Fixes inaccuracies in the documentation for disabling Spring Cloud Bindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,19 +32,19 @@ The buildpack will do the following:
 [c]: https://github.com/buildpacks/spec/blob/main/extensions/bindings.md
 
 ## Configuration
-| Environment Variable | Description
-| -------------------- | -----------
-| `$BP_SPRING_CLOUD_BINDINGS_DISABLED` | Whether to contribute Spring Boot cloud bindings support.  Defaults to y.
-| `$BPL_SPRING_CLOUD_BINDINGS_DISABLED` | Whether to auto-configure Spring Boot environment properties from bindings.  Defaults to y.
-| `$BPL_SPRING_CLOUD_BINDINGS_ENABLED` | Deprecated in favour of `$BPL_SPRING_CLOUD_BINDINGS_DISABLED`. Whether to auto-configure Spring Boot environment properties from bindings.  Defaults to y.
+| Environment Variable                  | Description                                                                                                                                                                                                                                                             |
+| ------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `$BP_SPRING_CLOUD_BINDINGS_DISABLED`  | Whether to contribute Spring Cloud Bindings support to the image at build time.  Defaults to false.                                                                                                                                                                     |
+| `$BPL_SPRING_CLOUD_BINDINGS_DISABLED` | Whether to auto-configure Spring Boot environment properties from bindings at runtime. This requires Spring Cloud Bindings to have been installed at build time or it will do nothing. Defaults to false.                                                               |
+| `$BPL_SPRING_CLOUD_BINDINGS_ENABLED`  | Deprecated in favour of `$BPL_SPRING_CLOUD_BINDINGS_DISABLED`. Whether to auto-configure Spring Boot environment properties from bindings at runtime. This requires Spring Cloud Bindings to have been installed at build time or it will do nothing. Defaults to true. |
 
 ## Bindings
 The buildpack optionally accepts the following bindings:
 
 ### Type: `dependency-mapping`
-|Key                   | Value   | Description
-|----------------------|---------|------------
-|`<dependency-digest>` | `<uri>` | If needed, the buildpack will fetch the dependency with digest `<dependency-digest>` from `<uri>`
+| Key                   | Value   | Description                                                                                       |
+| --------------------- | ------- | ------------------------------------------------------------------------------------------------- |
+| `<dependency-digest>` | `<uri>` | If needed, the buildpack will fetch the dependency with digest `<dependency-digest>` from `<uri>` |
 
 ## License
 This buildpack is released under version 2.0 of the [Apache License][a].

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -33,9 +33,9 @@ api = "0.7"
 
   [[metadata.configurations]]
     build = true
-    default = "true"
+    default = "false"
     description = "whether to contribute Spring Boot cloud bindings support"
-    name = "BP_SPRING_CLOUD_BINDINGS_ENABLED"
+    name = "BP_SPRING_CLOUD_BINDINGS_DISABLED"
 
   [[metadata.configurations]]
     default = "true"


### PR DESCRIPTION
## Summary

Cleans up a couple of issues with the documentation around disabling Spring Cloud Bindings at build and runtime.

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
