### PR TITLE
Include size for each slice

### DIFF
--- a/boot/build.go
+++ b/boot/build.go
@@ -186,7 +186,7 @@ func (b Build) Build(context libcnb.BuildContext) (libcnb.BuildResult, error) {
 				for name, paths := range layer {
 					size, err := calcSize(paths)
 					if err != nil {
-						size = "(error)"
+						size = "size unavailable"
 					}
 
 					b.Logger.Body(fmt.Sprintf("%s (%s)", name, size))


### PR DESCRIPTION
This PR will walk the location of each slice, under the application directory, and include the size of the slice next to the name. This provides some additional information to understand the image that's being generated. There is a minor performance hit in doing this, basically that the buildpack needs to walk the application directory. This took around 160ms on my laptop for a few of our test apps. That is pretty quick compared to tasks like Maven/Gradle build, but if this becomes too much we could add a property to disable it.

Resolves #178 

Signed-off-by: Daniel Mikusa <dmikusa@vmware.com>
