### PR TITLE
Implement RFC 0050: Rename Buildpack

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # `gcr.io/paketo-buildpacks/spring-boot`
-The Paketo Spring Boot Buildpack is a Cloud Native Buildpack that contributes Spring Boot dependency information and slices an application into multiple layers.
+The Paketo Buildpack for Spring Boot is a Cloud Native Buildpack that contributes Spring Boot dependency information and slices an application into multiple layers.
 
 ## Behavior
 

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -19,7 +19,7 @@ api = "0.7"
   homepage = "https://github.com/paketo-buildpacks/spring-boot"
   id = "paketo-buildpacks/spring-boot"
   keywords = ["java", "spring", "spring-boot"]
-  name = "Paketo Spring Boot Buildpack"
+  name = "Paketo Buildpack for Spring Boot"
   sbom-formats = ["application/vnd.cyclonedx+json", "application/vnd.syft+json"]
   version = "{{.version}}"
 


### PR DESCRIPTION
Renames 'Paketo Spring Boot Buildpack' to 'Paketo Buildpack for Spring Boot'.

Implements RFC 0050, https://github.com/paketo-buildpacks/rfcs/issues/233, for this buildpack.

Signed-off-by: Daniel Mikusa <dmikusa@vmware.com>
