### PR TITLE
Added support for argument file provided by Spring Boot for native bu…

### DIFF
--- a/boot/build.go
+++ b/boot/build.go
@@ -129,6 +129,7 @@ func (b Build) Build(context libcnb.BuildContext) (libcnb.BuildResult, error) {
 		}
 		classpathLayer.Logger = b.Logger
 		result.Layers = append(result.Layers, classpathLayer)
+
 	} else {
 		// contribute Spring Cloud Bindings - false by default
 		if !cr.ResolveBool("BP_SPRING_CLOUD_BINDINGS_DISABLED") {

--- a/boot/native_image.go
+++ b/boot/native_image.go
@@ -17,6 +17,7 @@ package boot
 
 import (
 	"fmt"
+	"github.com/paketo-buildpacks/libpak/sherpa"
 	"os"
 	"path/filepath"
 	"strings"
@@ -65,6 +66,15 @@ func (n NativeImageClasspath) Contribute(layer libcnb.Layer) (libcnb.Layer, erro
 			string(filepath.ListSeparator),
 			strings.Join(cp, string(filepath.ListSeparator)),
 		)
+
+		nativeImageArgFile := filepath.Join(n.ApplicationPath, "META-INF", "native-image", "argfile")
+		if exists, err := sherpa.Exists(nativeImageArgFile); err != nil{
+			return libcnb.Layer{}, fmt.Errorf("unable to check for native-image arguments file at %s\n%w", nativeImageArgFile, err)
+		} else if exists{
+			lc.Logger.Bodyf(fmt.Sprintf("native args file %s", nativeImageArgFile))
+			layer.BuildEnvironment.Default("BP_NATIVE_IMAGE_BUILD_ARGUMENTS_FILE", nativeImageArgFile)
+		}
+
 		return layer, nil
 	})
 }


### PR DESCRIPTION
…ilds

<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
Addresses paketo-buildpacks/native-image#204 by setting the enviornment variable `BP_NATIVE_IMAGE_BUILD_ARGUMENTS_FILE` when an argfile is found at the expected location of `META-INF/native-image/argfile`. The native-image buildpack can read this variable and add the argfile to the `native-image` build command.

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
