### PR TITLE
Revert "Adds spring-boot-native build plan entry to trigger native-build"

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,9 +25,6 @@ The buildpack will do the following:
       * Contributes application slices as defined by the layer's index
     * If the application is a reactive web application
       * Configures `$BPL_JVM_THREAD_COUNT` to 50
-* If `<APPLICATION_ROOT>/META-INF/native-image/argfile` exists:
-  * The default value of the environment variable `BP_NATIVE_IMAGE_BUILD_ARGUMENTS_FILE` is set to the absolute path to this file
-  * A build plan entry is provided, `native-image-argfile`, which can be required by `native-image` to automatically trigger a native image build
 * When contributing to a native image application:
    * Adds classes from the executable JAR and entries from `classpath.idx` to the build-time class path, so they are available to `native-image`
 

--- a/boot/build.go
+++ b/boot/build.go
@@ -113,19 +113,12 @@ func (b Build) Build(context libcnb.BuildContext) (libcnb.BuildResult, error) {
 	}
 
 	buildNativeImage := false
-	nativeImageArgFile := ""
 	if n, ok, err := pr.Resolve("spring-boot"); err != nil {
 		return libcnb.BuildResult{}, fmt.Errorf("unable to resolve spring-boot plan entry\n%w", err)
 	} else if ok {
 		if v, ok := n.Metadata["native-image"].(bool); ok {
 			buildNativeImage = v
 		}
-	}
-	if _, ok, err := pr.Resolve("native-image-argfile"); err != nil {
-		return libcnb.BuildResult{}, fmt.Errorf("unable to resolve native-image-argfile plan entry\n%w", err)
-	} else if ok {
-		buildNativeImage = true
-		nativeImageArgFile = filepath.Join(context.Application.Path, "META-INF", "native-image", "argfile")
 	}
 
 	if buildNativeImage {
@@ -134,7 +127,6 @@ func (b Build) Build(context libcnb.BuildContext) (libcnb.BuildResult, error) {
 		if err != nil {
 			return libcnb.BuildResult{}, fmt.Errorf("unable to create NativeImageClasspath\n%w", err)
 		}
-		classpathLayer.NativeArgFile = nativeImageArgFile
 		classpathLayer.Logger = b.Logger
 		result.Layers = append(result.Layers, classpathLayer)
 

--- a/boot/build_test.go
+++ b/boot/build_test.go
@@ -49,7 +49,6 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 		Expect(err).NotTo(HaveOccurred())
 
 		Expect(os.MkdirAll(filepath.Join(ctx.Application.Path, "META-INF"), 0755)).To(Succeed())
-		Expect(os.MkdirAll(filepath.Join(ctx.Application.Path, "META-INF", "native-image"), 0755)).To(Succeed())
 
 		ctx.Buildpack.Metadata = map[string]interface{}{
 			"dependencies": []map[string]interface{}{
@@ -316,32 +315,6 @@ Spring-Boot-Lib: BOOT-INF/lib
 
 			Expect(result.Slices).To(HaveLen(0))
 		})
-	})
-
-	context("when a native-image argfile is found", func() {
-		it.Before(func() {
-			ctx.Plan.Entries = append(ctx.Plan.Entries, libcnb.BuildpackPlanEntry{
-				Name:     "native-image-argfile",
-				Metadata: map[string]interface{}{"native-image": true},
-			})
-		})
-
-		it("contributes a native image build", func() {
-			Expect(os.WriteFile(filepath.Join(ctx.Application.Path, "META-INF", "native-image", "argfile"), []byte(`args`), 0644)).To(Succeed())
-			Expect(os.WriteFile(filepath.Join(ctx.Application.Path, "META-INF", "MANIFEST.MF"), []byte(`
-Spring-Boot-Version: 1.1.1
-Spring-Boot-Classes: BOOT-INF/classes
-Spring-Boot-Lib: BOOT-INF/lib
-`), 0644)).To(Succeed())
-
-			result, err := build.Build(ctx)
-			Expect(err).NotTo(HaveOccurred())
-
-			Expect(result.Layers).To(HaveLen(1))
-			Expect(result.Layers[0].Name()).To(Equal("Class Path"))
-			Expect(result.Slices).To(HaveLen(0))
-		})
-
 	})
 
 	context("set BP_SPRING_CLOUD_BINDINGS_DISABLED to true", func() {

--- a/boot/detect.go
+++ b/boot/detect.go
@@ -17,54 +17,29 @@
 package boot
 
 import (
-	"fmt"
 	"github.com/buildpacks/libcnb"
-	"github.com/paketo-buildpacks/libpak/sherpa"
-	"path/filepath"
 )
 
 const (
 	PlanEntrySpringBoot     = "spring-boot"
-	PlanEntryNativeArgFile  = "native-image-argfile"
 	PlanEntryJVMApplication = "jvm-application"
 )
 
 type Detect struct{}
 
 func (Detect) Detect(context libcnb.DetectContext) (libcnb.DetectResult, error) {
-	result := libcnb.DetectResult{
+	return libcnb.DetectResult{
 		Pass: true,
 		Plans: []libcnb.BuildPlan{
 			{
 				Provides: []libcnb.BuildPlanProvide{
-					{Name: PlanEntrySpringBoot},
+					{Name: "spring-boot"},
 				},
 				Requires: []libcnb.BuildPlanRequire{
-					{Name: PlanEntryJVMApplication},
-					{Name: PlanEntrySpringBoot},
+					{Name: "jvm-application"},
+					{Name: "spring-boot"},
 				},
 			},
 		},
-	}
-	nativeImageArgFile := filepath.Join(context.Application.Path, "META-INF", "native-image", "argfile")
-	if exists, err := sherpa.Exists(nativeImageArgFile); err != nil{
-		return libcnb.DetectResult{}, fmt.Errorf("unable to check for native-image arguments file at %s\n%w", nativeImageArgFile, err)
-	} else if exists{
-		result = libcnb.DetectResult{
-			Pass: true,
-			Plans: []libcnb.BuildPlan{
-				{
-					Provides: []libcnb.BuildPlanProvide{
-						{Name: PlanEntrySpringBoot},
-						{Name: PlanEntryNativeArgFile},
-					},
-					Requires: []libcnb.BuildPlanRequire{
-						{Name: PlanEntrySpringBoot},
-						{Name: PlanEntryJVMApplication},
-					},
-				},
-			},
-		}
-	}
-	return result, nil
+	}, nil
 }

--- a/boot/detect_test.go
+++ b/boot/detect_test.go
@@ -17,8 +17,6 @@
 package boot_test
 
 import (
-	"os"
-	"path/filepath"
 	"testing"
 
 	"github.com/buildpacks/libcnb"
@@ -36,8 +34,7 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 		detect boot.Detect
 	)
 
-	it("always passes for standard build", func() {
-		Expect(os.RemoveAll(filepath.Join(ctx.Application.Path, "META-INF", "native-image"))).To(Succeed())
+	it("always passes", func() {
 		Expect(detect.Detect(ctx)).To(Equal(libcnb.DetectResult{
 			Pass: true,
 			Plans: []libcnb.BuildPlan{
@@ -48,26 +45,6 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 					Requires: []libcnb.BuildPlanRequire{
 						{Name: "jvm-application"},
 						{Name: "spring-boot"},
-					},
-				},
-			},
-		}))
-	})
-
-	it("always passes for native build", func() {
-		Expect(os.MkdirAll(filepath.Join(ctx.Application.Path, "META-INF", "native-image"), 0755)).To(Succeed())
-		Expect(os.WriteFile(filepath.Join(ctx.Application.Path, "META-INF", "native-image", "argfile"), []byte("file-data"), 0644)).To(Succeed())
-		Expect(detect.Detect(ctx)).To(Equal(libcnb.DetectResult{
-			Pass: true,
-			Plans: []libcnb.BuildPlan{
-				{
-					Provides: []libcnb.BuildPlanProvide{
-						{Name: "spring-boot"},
-						{Name: "native-image-argfile"},
-					},
-					Requires: []libcnb.BuildPlanRequire{
-						{Name: "spring-boot"},
-						{Name: "jvm-application"},
 					},
 				},
 			},

--- a/boot/native_image.go
+++ b/boot/native_image.go
@@ -17,6 +17,7 @@ package boot
 
 import (
 	"fmt"
+	"github.com/paketo-buildpacks/libpak/sherpa"
 	"os"
 	"path/filepath"
 	"strings"
@@ -32,7 +33,6 @@ type NativeImageClasspath struct {
 	Logger          bard.Logger
 	ApplicationPath string
 	Manifest        *properties.Properties
-	NativeArgFile   string
 }
 
 func NewNativeImageClasspath(appDir string, manifest *properties.Properties) (NativeImageClasspath, error) {
@@ -67,8 +67,12 @@ func (n NativeImageClasspath) Contribute(layer libcnb.Layer) (libcnb.Layer, erro
 			strings.Join(cp, string(filepath.ListSeparator)),
 		)
 
-		if n.NativeArgFile != ""{
-			layer.BuildEnvironment.Default("BP_NATIVE_IMAGE_BUILD_ARGUMENTS_FILE", n.NativeArgFile)
+		nativeImageArgFile := filepath.Join(n.ApplicationPath, "META-INF", "native-image", "argfile")
+		if exists, err := sherpa.Exists(nativeImageArgFile); err != nil{
+			return libcnb.Layer{}, fmt.Errorf("unable to check for native-image arguments file at %s\n%w", nativeImageArgFile, err)
+		} else if exists{
+			lc.Logger.Bodyf(fmt.Sprintf("native args file %s", nativeImageArgFile))
+			layer.BuildEnvironment.Default("BP_NATIVE_IMAGE_BUILD_ARGUMENTS_FILE", nativeImageArgFile)
 		}
 
 		return layer, nil

--- a/boot/native_image_test.go
+++ b/boot/native_image_test.go
@@ -127,22 +127,11 @@ func testNativeImage(t *testing.T, context spec.G, it spec.S) {
 		})
 
 		it("ensures BP_NATIVE_IMAGE_BUILD_ARGUMENTS_FILE is set when argfile is found", func() {
-			contributor.NativeArgFile = filepath.Join(appDir, "META-INF", "native-image", "argfile")
 			layer, err := contributor.Contribute(layer)
 			Expect(err).NotTo(HaveOccurred())
 
 			Expect(layer.BuildEnvironment["BP_NATIVE_IMAGE_BUILD_ARGUMENTS_FILE.default"]).To(Equal(
 				filepath.Join(appDir, "META-INF", "native-image", "argfile")))
-			Expect(layer.LayerTypes.Build).To(BeTrue())
-			Expect(layer.LayerTypes.Launch).To(BeFalse())
-		})
-
-		it("ensures BP_NATIVE_IMAGE_BUILD_ARGUMENTS_FILE is not set when argfile is not found", func() {
-			contributor.NativeArgFile = ""
-			layer, err := contributor.Contribute(layer)
-			Expect(err).NotTo(HaveOccurred())
-
-			Expect(layer.BuildEnvironment["BP_NATIVE_IMAGE_BUILD_ARGUMENTS_FILE.default"]).To(Equal(""))
 			Expect(layer.LayerTypes.Build).To(BeTrue())
 			Expect(layer.LayerTypes.Launch).To(BeFalse())
 		})


### PR DESCRIPTION
Reverts paketo-buildpacks/spring-boot#279

Due to a bug with the Gradle Boot plugin which leads to native builds being triggered for non-native apps, and the possible unreliability of using the presence of `META-INF/native-image/argfile` as a trigger, this change will be reverted until a more suitable solution to auto-trigger native builds is found.