### PR TITLE
Changed SCB dependency URI to Maven Central

### DIFF
--- a/.github/pipeline-descriptor.yml
+++ b/.github/pipeline-descriptor.yml
@@ -20,6 +20,6 @@ dependencies:
 - id:   spring-cloud-bindings
   uses: docker://ghcr.io/paketo-buildpacks/actions/maven-dependency:main
   with:
-    uri:         https://repo.spring.io/release
+    uri:         https://repo1.maven.org/maven2
     group_id:    org.springframework.cloud
     artifact_id: spring-cloud-bindings

--- a/.github/workflows/pb-update-spring-cloud-bindings.yml
+++ b/.github/workflows/pb-update-spring-cloud-bindings.yml
@@ -46,7 +46,7 @@ jobs:
               with:
                 artifact_id: spring-cloud-bindings
                 group_id: org.springframework.cloud
-                uri: https://repo.spring.io/release
+                uri: https://repo1.maven.org/maven2
             - name: Update Buildpack Dependency
               id: buildpack
               run: |-

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -50,14 +50,14 @@ api = "0.7"
     name = "BPL_SPRING_CLOUD_BINDINGS_DISABLED"
 
   [[metadata.dependencies]]
-    cpes = ["cpe:2.3:a:vmware:spring_cloud_bindings:1.10.0:*:*:*:*:*:*:*"]
+    cpes = ["cpe:2.3:a:vmware:spring_cloud_bindings:1.11.0:*:*:*:*:*:*:*"]
     id = "spring-cloud-bindings"
     name = "Spring Cloud Bindings"
-    purl = "pkg:generic/springframework/spring-cloud-bindings@1.10.0"
-    sha256 = "1f5b781f8bd0d6b85ab2462e4b98d36782a2227fef5b168db174b3959a0ebebe"
+    purl = "pkg:generic/springframework/spring-cloud-bindings@1.11.0"
+    sha256 = "9f76c9c93748472a9f145999d4da99c1d8cb070872bba574843c45ef1d14c27f"
     stacks = ["io.buildpacks.stacks.bionic", "io.paketo.stacks.tiny", "*"]
-    uri = "https://repo.spring.io/release/org/springframework/cloud/spring-cloud-bindings/1.10.0/spring-cloud-bindings-1.10.0.jar"
-    version = "1.10.0"
+    uri = "https://repo1.maven.org/maven2/org/springframework/cloud/spring-cloud-bindings/1.11.0/spring-cloud-bindings-1.11.0.jar"
+    version = "1.11.0"
 
     [[metadata.dependencies.licenses]]
       type = "Apache-2.0"


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
Fixes #304 - due to changes to permissions on repo.spring.io access, this PR changes the URI for the dependency Spring Cloud Bindings to Maven Central.

This will only ensure the next release of the Spring Boot buildpack resolves the Spring Cloud Bindings dependency successfully. Users will need to ensure they use the latest version of this buildpack and the [Java](https://github.com/paketo-buildpacks/java) composite buildpack(s) that include it, to prevent failing builds due to #304.

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
