### PR TITLE
update the `peter-evans/create-pull-request` action from v2 to v3

### DIFF
--- a/.github/workflows/update-spring-generations.yml
+++ b/.github/workflows/update-spring-generations.yml
@@ -28,7 +28,7 @@ jobs:
                 git checkout -- .
               env:
                 CONTENT: ${{ steps.generations.outputs.content }}
-            - uses: peter-evans/create-pull-request@v3
+            - uses: peter-evans/create-pull-request@v4
               with:
                 author: ${{ secrets.JAVA_GITHUB_USERNAME }} <${{ secrets.JAVA_GITHUB_USERNAME }}@users.noreply.github.com>
                 body: Bumps Spring Generations


### PR DESCRIPTION
## Summary

Has been done for the pipeline builder managed pipelines already: https://github.com/paketo-buildpacks/pipeline-builder/commit/08e8d764a0cb94c4e722d5797ad7a7daaba5fbde

According to the [release notes](https://github.com/peter-evans/create-pull-request/releases/tag/v4.0.0), the major bump is only (potentially) breaking if `add-paths` is used or if self-hosted runners are used.

## Use Cases

The new major version uses the new way of producing outputs in a github action as the old way is deprecated and will be removed (31st May 2023).

See https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
