### PR TITLE
Adds support for Boot 3.x compatible Spring Cloud Bindings dependency…

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@ The buildpack will do the following:
 * When contributing to a JVM application:
     * Contributes [Spring Cloud Bindings][b] as an application dependency
       * This enables bindings-aware Spring Boot auto-configuration when [CNB bindings][c] are present during launch
+      * The version of the Spring Cloud Bindings library to install will be determined by (in order):
+        * An explicit value set in `BP_SPRING_CLOUD_BINDINGS_VERSION` by the user
+        * The Spring Boot version from  `<APPLICATION_ROOT>/META-INF/MANIFEST.MF`: Boot 2.x will install Spring Cloud Bindings v1, Boot 3.x will install Spring Cloud Bindings v2
+        * The default value for `BP_SPRING_CLOUD_BINDINGS_VERSION`
     * If `<APPLICATION_ROOT>/META-INF/MANIFEST.MF` contains a `Spring-Boot-Layers-Index` entry
       * Contributes application slices as defined by the layer's index
     * If the application is a reactive web application
@@ -39,6 +43,7 @@ The buildpack will do the following:
 | `$BP_SPRING_CLOUD_BINDINGS_DISABLED`  | Whether to contribute Spring Cloud Bindings support to the image at build time.  Defaults to false.                                                                                                                                                                     |
 | `$BPL_SPRING_CLOUD_BINDINGS_DISABLED` | Whether to auto-configure Spring Boot environment properties from bindings at runtime. This requires Spring Cloud Bindings to have been installed at build time or it will do nothing. Defaults to false.                                                               |
 | `$BPL_SPRING_CLOUD_BINDINGS_ENABLED`  | Deprecated in favour of `$BPL_SPRING_CLOUD_BINDINGS_DISABLED`. Whether to auto-configure Spring Boot environment properties from bindings at runtime. This requires Spring Cloud Bindings to have been installed at build time or it will do nothing. Defaults to true. |
+| `$BP_SPRING_CLOUD_BINDINGS_VERSION`  | Explicit version of Spring Cloud Bindings library to install.  Defaults to `1`.   
 
 ## Bindings
 The buildpack optionally accepts the following bindings:

--- a/README.md
+++ b/README.md
@@ -24,7 +24,6 @@ The buildpack will do the following:
       * The version of the Spring Cloud Bindings library to install will be determined by (in order):
         * An explicit value set in `BP_SPRING_CLOUD_BINDINGS_VERSION` by the user
         * The Spring Boot version from  `<APPLICATION_ROOT>/META-INF/MANIFEST.MF`: Boot 2.x will install Spring Cloud Bindings v1, Boot 3.x will install Spring Cloud Bindings v2
-        * The default value for `BP_SPRING_CLOUD_BINDINGS_VERSION`
     * If `<APPLICATION_ROOT>/META-INF/MANIFEST.MF` contains a `Spring-Boot-Layers-Index` entry
       * Contributes application slices as defined by the layer's index
     * If the application is a reactive web application

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ The buildpack will do the following:
 | `$BP_SPRING_CLOUD_BINDINGS_DISABLED`  | Whether to contribute Spring Cloud Bindings support to the image at build time.  Defaults to false.                                                                                                                                                                     |
 | `$BPL_SPRING_CLOUD_BINDINGS_DISABLED` | Whether to auto-configure Spring Boot environment properties from bindings at runtime. This requires Spring Cloud Bindings to have been installed at build time or it will do nothing. Defaults to false.                                                               |
 | `$BPL_SPRING_CLOUD_BINDINGS_ENABLED`  | Deprecated in favour of `$BPL_SPRING_CLOUD_BINDINGS_DISABLED`. Whether to auto-configure Spring Boot environment properties from bindings at runtime. This requires Spring Cloud Bindings to have been installed at build time or it will do nothing. Defaults to true. |
-| `$BP_SPRING_CLOUD_BINDINGS_VERSION`  | Explicit version of Spring Cloud Bindings library to install.  Defaults to `1`.   
+| `$BP_SPRING_CLOUD_BINDINGS_VERSION`  | Explicit version of Spring Cloud Bindings library to install. 
 
 ## Bindings
 The buildpack optionally accepts the following bindings:

--- a/boot/build.go
+++ b/boot/build.go
@@ -155,9 +155,10 @@ func (b Build) Build(context libcnb.BuildContext) (libcnb.BuildResult, error) {
 			scbVer, scbSet := cr.Resolve("BP_SPRING_CLOUD_BINDINGS_VERSION")
 			if !scbSet {
 				scbVerFromBoot, err := getSCBVersion(version)
-				if err == nil{
-					scbVer = scbVerFromBoot
-				}
+				if err != nil{
+					return libcnb.BuildResult{}, fmt.Errorf("Unable to read the Spring Boot version from META-INF/MANIFEST.MF. Please set BP_SPRING_CLOUD_BINDINGS_VERSION to force a version or BP_SPRING_CLOUD_BINDINGS_DISABLED to bypass installing Spring Cloud Bindings")
+				} 
+				scbVer = scbVerFromBoot
 			}
 
 			dep, err := dr.Resolve("spring-cloud-bindings", scbVer)

--- a/boot/build.go
+++ b/boot/build.go
@@ -24,8 +24,10 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 
+	"github.com/Masterminds/semver/v3"
 	"github.com/buildpacks/libcnb"
 	"github.com/magiconair/properties"
 	"github.com/paketo-buildpacks/libjvm"
@@ -40,6 +42,8 @@ const (
 	LabelImageVersion                  = "org.opencontainers.image.version"
 	LabelBootConfigurationMetadata     = "org.springframework.boot.spring-configuration-metadata.json"
 	LabelDataFlowConfigurationMetadata = "org.springframework.cloud.dataflow.spring-configuration-metadata.json"
+	SpringCloudBindingsBoot2		   = "1"
+	SpringCloudBindingsBoot3		   = "2"
 )
 
 type Build struct {
@@ -148,7 +152,15 @@ func (b Build) Build(context libcnb.BuildContext) (libcnb.BuildResult, error) {
 			result.Layers = append(result.Layers, h)
 			result.BOM.Entries = append(result.BOM.Entries, be)
 
-			dep, err := dr.Resolve("spring-cloud-bindings", "")
+			scbVer, scbSet := cr.Resolve("BP_SPRING_CLOUD_BINDINGS_VERSION")
+			if !scbSet {
+				scbVerFromBoot, err := getSCBVersion(version)
+				if err == nil{
+					scbVer = scbVerFromBoot
+				}
+			}
+
+			dep, err := dr.Resolve("spring-cloud-bindings", scbVer)
 			if err != nil {
 				return libcnb.BuildResult{}, fmt.Errorf("unable to find dependency\n%w", err)
 			}
@@ -342,4 +354,26 @@ func FindExistingDependency(jars []libjvm.MavenJAR, dependencyName string) bool 
 		}
 	}
 	return false
+}
+
+func getSCBVersion (manifestVer string) (string, error) {
+	bootTwoConstraint, _ := semver.NewConstraint("<= 3.0.0")
+	bv, err := bootVersion(manifestVer)
+	if err != nil{
+		return SpringCloudBindingsBoot2, err
+	}
+	if bootTwoConstraint.Check(bv) {
+		return SpringCloudBindingsBoot2, nil
+	}
+	return SpringCloudBindingsBoot3, nil
+}
+
+func bootVersion (version string) (*semver.Version, error) {
+	pattern := regexp.MustCompile(`[\d]+(?:\.[\d]+(?:\.[\d]+)?)?`)
+	bootV := pattern.FindString(version)
+	semverBoot, err := semver.NewVersion(bootV)
+	if err != nil{
+		return nil, fmt.Errorf("unable to parse spring-boot version\n%w", err)
+	}
+	return semverBoot, nil
 }

--- a/boot/build_test.go
+++ b/boot/build_test.go
@@ -345,11 +345,7 @@ Spring-Boot-Lib: BOOT-INF/lib
 
 	context("set BP_SPRING_CLOUD_BINDINGS_DISABLED to true", func() {
 		it.Before(func() {
-			Expect(os.Setenv("BP_SPRING_CLOUD_BINDINGS_DISABLED", "true")).To(Succeed())
-		})
-
-		it.After(func() {
-			Expect(os.Unsetenv(("BP_SPRING_CLOUD_BINDINGS_DISABLED"))).To(Succeed())
+			t.Setenv("BP_SPRING_CLOUD_BINDINGS_DISABLED", "true")
 		})
 
 		it("contributes to the result for API 0.7+", func() {
@@ -566,7 +562,7 @@ Spring-Boot-Lib: BOOT-INF/lib
 						Spring-Boot-Classes: BOOT-INF/classes
 						Spring-Boot-Lib: BOOT-INF/lib
 						`), 0644)).To(Succeed())
-			Expect(os.Setenv("BP_SPRING_CLOUD_BINDINGS_VERSION", "2")).To(Succeed())
+			t.Setenv("BP_SPRING_CLOUD_BINDINGS_VERSION", "2")
 			result, err := build.Build(ctx)
 			Expect(err).NotTo(HaveOccurred())
 			

--- a/boot/native_image_test.go
+++ b/boot/native_image_test.go
@@ -126,6 +126,10 @@ func testNativeImage(t *testing.T, context spec.G, it spec.S) {
 			Expect(ioutil.WriteFile(filepath.Join(appDir, "META-INF", "native-image", "argfile"), []byte("file-data"), 0644)).To(Succeed())
 		})
 
+		it.After(func() {
+			Expect(os.RemoveAll(filepath.Join(appDir, "META-INF"))).To(Succeed())
+		})
+
 		it("ensures BP_NATIVE_IMAGE_BUILD_ARGUMENTS_FILE is set when argfile is found", func() {
 			layer, err := contributor.Contribute(layer)
 			Expect(err).NotTo(HaveOccurred())

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -48,6 +48,12 @@ api = "0.7"
     description = "whether to auto-configure Spring Boot environment properties from bindings"
     launch = true
     name = "BPL_SPRING_CLOUD_BINDINGS_DISABLED"
+  
+  [[metadata.configurations]]
+    build = true
+    default = "1"
+    description = "default version of Spring Cloud Bindings library to contribute"
+    name = "BP_SPRING_CLOUD_BINDINGS_VERSION"
 
   [[metadata.dependencies]]
     cpes = ["cpe:2.3:a:vmware:spring_cloud_bindings:1.13.0:*:*:*:*:*:*:*"]
@@ -58,6 +64,20 @@ api = "0.7"
     stacks = ["io.buildpacks.stacks.bionic", "io.paketo.stacks.tiny", "*"]
     uri = "https://repo1.maven.org/maven2/org/springframework/cloud/spring-cloud-bindings/1.13.0/spring-cloud-bindings-1.13.0.jar"
     version = "1.13.0"
+
+    [[metadata.dependencies.licenses]]
+      type = "Apache-2.0"
+      uri = "https://github.com/spring-cloud/spring-cloud-bindings/blob/main/LICENSE"
+
+  [[metadata.dependencies]]
+    cpes = ["cpe:2.3:a:vmware:spring_cloud_bindings:2.0.0:*:*:*:*:*:*:*"]
+    id = "spring-cloud-bindings"
+    name = "Spring Cloud Bindings"
+    purl = "pkg:generic/springframework/spring-cloud-bindings@2.0.0"
+    sha256 = ""
+    stacks = ["io.buildpacks.stacks.bionic", "io.paketo.stacks.tiny", "*"]
+    uri = "https://repo1.maven.org/maven2/org/springframework/cloud/spring-cloud-bindings/2.0.0/spring-cloud-bindings-2.0.0.jar"
+    version = "2.0.0"
 
     [[metadata.dependencies.licenses]]
       type = "Apache-2.0"

--- a/spring-generations.toml
+++ b/spring-generations.toml
@@ -1444,6 +1444,16 @@
     Name = "2.0.x"
     OSS = "2023-11-16"
 
+  [[Projects.Generations]]
+    Commercial = "2025-09-11"
+    Name = "2.1.x"
+    OSS = "2024-05-11"
+
+  [[Projects.Generations]]
+    Commercial = "2026-03-16"
+    Name = "2.2.x"
+    OSS = "2024-11-16"
+
 [[Projects]]
   Name = "Spring Integration"
   Slug = "spring-integration"


### PR DESCRIPTION
… version

<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
The Spring Cloud Bindings (SCB) library needed changes to be compatible with Spring Boot 3. A new major version will need to be released soon with these changes. This PR adds support for a second major version of SCB via a new dependency and an optional configuration variable.

## Use Cases
The decision process on which SCB version the buildpack should install is as follows:

1. If the user has set `BP_SPRING_CLOUD_BINDINGS_VERSION`, the value for this will be resolved against the buildpack's dependencies.
2. The Spring Boot version from the manifest file is used - currently this means:
- Boot 2.x will result in SCB 1.x
- Boot 3.x will result in SCB 2.x
3. The fallback will be the default value for `BP_SPRING_CLOUD_BINDINGS_VERSION`, currently set to `1`.

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
