### PR TITLE
correctly handles case where no jar was found

### DIFF
--- a/boot/build.go
+++ b/boot/build.go
@@ -510,6 +510,7 @@ func (b *Build) findSpringBootExecutableJAR(appPath string) (string, *properties
 	props := &properties.Properties{}
 	jarPath := ""
 	stopWalk := errors.New("stop walking")
+	noJar := errors.New("unable to find a jar file")
 
 	fileSystem := os.DirFS(appPath)
 	err := fs.WalkDir(fileSystem, ".", func(path string, dirEntry fs.DirEntry, err error) error {
@@ -541,9 +542,12 @@ func (b *Build) findSpringBootExecutableJAR(appPath string) (string, *properties
 			jarPath = fullPath
 			return stopWalk
 		}
-
-		return nil
+		return noJar
 	})
+
+	if errors.Is(err, noJar) || err == nil{
+		return "", &properties.Properties{}, nil
+	}
 
 	if err != nil && !errors.Is(err, stopWalk) {
 		return "", nil, err


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
Fixes #474 

## Use Cases
Walking the application path to find a non-exploded jar did not handle finding no suitable jar correctly - this fix ensures that 
either no jar being found, or a non-boot jar being found, results in the expected backing off of the Boot buildpack during build.

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
