### PR TITLE
bug: close #563 Fix Spring Generations

### DIFF
--- a/boot/generation_validator_test.go
+++ b/boot/generation_validator_test.go
@@ -59,7 +59,7 @@ func testGenerationValidator(t *testing.T, context spec.G, it spec.S) {
 	})
 
 	it("ignores unknown version", func() {
-		Expect(gv.Validate("spring-boot", "2.7.0.RELEASE")).NotTo(HaveOccurred())
+		Expect(gv.Validate("spring-boot", "2.8.0.RELEASE")).NotTo(HaveOccurred())
 		Expect(b.Len()).To(BeZero())
 	})
 
@@ -69,22 +69,16 @@ func testGenerationValidator(t *testing.T, context spec.G, it spec.S) {
 	})
 
 	it("does not log warning", func() {
-		Expect(gv.Validate("spring-boot", "2.5.0.RELEASE")).NotTo(HaveOccurred())
+		Expect(gv.Validate("spring-boot", "3.5.0.RELEASE")).NotTo(HaveOccurred())
 		Expect(b.Len()).To(BeZero())
-	})
-
-	it("logs commercial warning", func() {
-		Expect(gv.Validate("spring-boot", "2.0.0.RELEASE")).NotTo(HaveOccurred())
-		Expect(b.String()).To(Equal(fmt.Sprintf("  %s\n", color.New(color.FgYellow, color.Bold, color.Faint).Sprint(
-			"This application uses Spring Boot 2.0.0.RELEASE. Commercial updates for 2.0.x ended on 2020-04-01."))))
 	})
 
 	it("logs open source warning", func() {
 		// implementation of Validate uses `time.Now()` and will eventually need to be updated
 		// `boot/testdata/test-spring-generations.toml has the defined generations for this test
-		Expect(gv.Validate("spring-boot", "2.2.0.RELEASE")).NotTo(HaveOccurred())
+		Expect(gv.Validate("spring-boot", "2.0.0.RELEASE")).NotTo(HaveOccurred())
 		Expect(b.String()).To(Equal(fmt.Sprintf("  %s\n", color.New(color.FgYellow, color.Bold, color.Faint).Sprint(
-			"This application uses Spring Boot 2.2.0.RELEASE. Open Source updates for 2.2.x ended on 2021-10-01."))))
+			"This application uses Spring Boot 2.0.0.RELEASE. Open Source updates for 2.0.x ended on 2019-03-31."))))
 	})
 
 }

--- a/boot/testdata/test-spring-generations.toml
+++ b/boot/testdata/test-spring-generations.toml
@@ -1,34 +1,47 @@
-[[projects]]
-  name = "Spring Boot"
-  slug = "spring-boot"
-  status = "ACTIVE"
+[[Projects]]
+  Name = "Spring AI"
+  Slug = "spring-ai"
+  Status = "ACTIVE"
 
-  [[projects.generations]]
-    name = "1.5.x"
-    oss = "2019-08-01"
-    commercial = "2019-09-01"
+  [[Projects.Generations]]
+    Commercial = "2032-06-30"
+    Name = "1.0.x"
+    OSS = "2026-06-30"
 
-  [[projects.generations]]
-    name = "2.0.x"
-    oss = "2019-04-03"
-    commercial = "2020-04-01"
+[[Projects]]
+  Name = "Spring Boot"
+  Slug = "spring-boot"
+  Status = "ACTIVE"
 
-  [[projects.generations]]
-    name = "2.1.x"
-    oss = "2019-10-01"
-    commercial = "2021-04-01"
+  [[Projects.Generations]]
+    Name = "1.5.x"
+    OSS = "2019-08-31"
 
-  [[projects.generations]]
-    name = "2.2.x"
-    oss = "2021-10-01"
-    commercial = "2032-11-15"
+  [[Projects.Generations]]
+    Name = "2.0.x"
+    OSS = "2019-03-31"
 
-  [[projects.generations]]
-    name = "2.3.x"
-    oss = "2021-05-15"
-    commercial = ""
+  [[Projects.Generations]]
+    Name = "2.5.x"
+    OSS = "2022-05-31"
 
-  [[projects.generations]]
-    name = "2.4.x"
-    oss = "2021-11-15"
-    commercial = ""
+  [[Projects.Generations]]
+    Name = "2.6.x"
+    OSS = "2022-11-30"
+
+  [[Projects.Generations]]
+    Name = "2.7.x"
+    OSS = "2023-06-30"
+
+  [[Projects.Generations]]
+    Name = "3.5.x"
+    OSS = "2026-06-30"
+
+  [[Projects.Generations]]
+    Name = "4.0.x"
+    OSS = "2026-12-31"
+
+[[Projects]]
+  Name = "Spring CLI"
+  Slug = "spring-cli"
+  Status = "END_OF_LIFE"


### PR DESCRIPTION
- Generated file has been using Uppercase for a while...
- Remove support for Commercial dates, it's an OSS project
- Replace deprecated `ioutil.ReadFile` with `os.ReadFile`

## Summary
Spring Generations warnings have been not working for a while because the text case changed from minor to upper.

## Use Cases
Spring Generations warns the user running EOL software

Remove the Commercial EOL since the project is OSS / independent from any vendor.

## Checklist
<!-- Please confirm the following -->
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [X] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [X] I have added an integration test, if necessary.
* [X] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [X] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
