### PR TITLE
fix: file time reset for kpack with BP_JVM_AOTCACHE_ENABLED

### DIFF
--- a/boot/spring_performance.go
+++ b/boot/spring_performance.go
@@ -121,9 +121,16 @@ func (s SpringPerformance) Contribute(layer libcnb.Layer) (libcnb.Layer, error) 
 		startClassValue, _ := s.Manifest.Get("Start-Class")
 
 		if err := fs.WalkDir(os.DirFS(s.AppPath), ".", func(path string, d fs.DirEntry, err error) error {
+			if err != nil {
+				return err
+			}
+			if path == "." {
+				// skip walk root, it is not needed and can break some builds eg. kpack
+				return nil
+			}
 			if baseTime, err := time.Parse(time.DateTime, "1980-01-01 00:00:01"); err != nil {
 				return fmt.Errorf("error parsing date-time\n%w", err)
-			} else if err := os.Chtimes(path, baseTime, baseTime); err != nil {
+			} else if err := os.Chtimes(filepath.Join(s.AppPath, path), baseTime, baseTime); err != nil {
 				return fmt.Errorf("error resetting file times\n%w", err)
 			}
 			return nil

--- a/boot/spring_performance_test.go
+++ b/boot/spring_performance_test.go
@@ -23,6 +23,7 @@ import (
 	"path/filepath"
 	"slices"
 	"testing"
+	"time"
 
 	"github.com/buildpacks/libcnb"
 	. "github.com/onsi/gomega"
@@ -36,17 +37,41 @@ import (
 	"github.com/paketo-buildpacks/spring-boot/v5/boot"
 )
 
+const javaVersion21Output = `openjdk version "21.0.5" 2024-10-15 LTS
+OpenJDK Runtime Environment Temurin-21.0.5+11 (build 21.0.5+11-LTS)
+OpenJDK 64-Bit Server VM Temurin-21.0.5+11 (build 21.0.5+11-LTS, mixed mode, sharing)`
+
+func createAppDir(path string) error {
+	if err := os.MkdirAll(filepath.Join(path, "META-INF"), 0755); err != nil {
+		return err
+	}
+	return os.MkdirAll(filepath.Join(path, "BOOT-INF", "lib"), 0755)
+}
+
+func mockExecute(args mock.Arguments) {
+	execution := args.Get(0).(effect.Execution)
+
+	if slices.Contains(execution.Args, "-version") && execution.Stderr != nil {
+		if _, err := io.WriteString(execution.Stderr, javaVersion21Output); err != nil {
+			panic(err)
+		}
+	}
+
+	if i := slices.Index(execution.Args, "--destination"); i >= 0 && i+1 < len(execution.Args) {
+		if err := createAppDir(execution.Args[i+1]); err != nil {
+			panic(err)
+		}
+	}
+}
+
 func testSpringPerformance(t *testing.T, context spec.G, it spec.S) {
 	var (
 		Expect = NewWithT(t).Expect
 
-		ctx                 libcnb.BuildContext
-		executor            *mocks.Executor
-		aotEnabled          bool
-		performanceType     boot.SpringPerformanceType
-		javaVersion21Output = `openjdk version "21.0.5" 2024-10-15 LTS
-OpenJDK Runtime Environment Temurin-21.0.5+11 (build 21.0.5+11-LTS)
-OpenJDK 64-Bit Server VM Temurin-21.0.5+11 (build 21.0.5+11-LTS, mixed mode, sharing)`
+		ctx             libcnb.BuildContext
+		executor        *mocks.Executor
+		aotEnabled      bool
+		performanceType boot.SpringPerformanceType
 	)
 
 	it.Before(func() {
@@ -58,8 +83,7 @@ OpenJDK 64-Bit Server VM Temurin-21.0.5+11 (build 21.0.5+11-LTS, mixed mode, sha
 		ctx.Application.Path, err = os.MkdirTemp("", "spring-performance-app-dir")
 		Expect(err).NotTo(HaveOccurred())
 
-		Expect(os.MkdirAll(filepath.Join(ctx.Application.Path, "META-INF"), 0755)).To(Succeed())
-		Expect(os.MkdirAll(filepath.Join(ctx.Application.Path, "BOOT-INF/lib"), 0755)).To(Succeed())
+		Expect(createAppDir(ctx.Application.Path)).To(Succeed())
 
 		executor = &mocks.Executor{}
 	})
@@ -77,15 +101,7 @@ OpenJDK 64-Bit Server VM Temurin-21.0.5+11 (build 21.0.5+11-LTS, mixed mode, sha
 		aotEnabled = true
 		performanceType = boot.CdsAotCache
 		dc := libpak.DependencyCache{CachePath: "testdata"}
-		executor.On("Execute", mock.Anything).
-			Return(nil).
-			Run(func(args mock.Arguments) {
-				execution := args.Get(0).(effect.Execution)
-				if (slices.Contains(execution.Args, "-version")) && execution.Stderr != nil {
-					_, err := io.WriteString(execution.Stderr, javaVersion21Output)
-					Expect(err).NotTo(HaveOccurred())
-				}
-			}).Return(nil)
+		executor.On("Execute", mock.Anything).Return(nil).Run(mockExecute)
 
 		Expect(os.WriteFile(filepath.Join(ctx.Application.Path, "META-INF", "MANIFEST.MF"), []byte(`
 Spring-Boot-Version: 3.3.1
@@ -190,15 +206,7 @@ Spring-Boot-Lib: BOOT-INF/lib
 		aotEnabled = false
 		performanceType = boot.CdsAotCache
 		dc := libpak.DependencyCache{CachePath: "testdata"}
-		executor.On("Execute", mock.Anything).
-			Return(nil).
-			Run(func(args mock.Arguments) {
-				execution := args.Get(0).(effect.Execution)
-				if slices.Contains(execution.Args, "-version") && execution.Stderr != nil {
-					_, err := io.WriteString(execution.Stderr, javaVersion21Output)
-					Expect(err).NotTo(HaveOccurred())
-				}
-			}).Return(nil)
+		executor.On("Execute", mock.Anything).Return(nil).Run(mockExecute)
 
 		Expect(os.WriteFile(filepath.Join(ctx.Application.Path, "META-INF", "MANIFEST.MF"), []byte(`
 Spring-Boot-Version: 3.3.1
@@ -231,20 +239,50 @@ Spring-Boot-Lib: BOOT-INF/lib
 
 	})
 
+	it("normalizes file times under the application directory but not the directory itself", func() {
+		aotEnabled = false
+		performanceType = boot.CdsAotCache
+		dc := libpak.DependencyCache{CachePath: "testdata"}
+		executor.On("Execute", mock.Anything).Return(nil).Run(mockExecute)
+
+		Expect(os.WriteFile(filepath.Join(ctx.Application.Path, "META-INF", "MANIFEST.MF"), []byte(`
+Spring-Boot-Version: 3.3.1
+Spring-Boot-Classes: BOOT-INF/classes
+Spring-Boot-Lib: BOOT-INF/lib
+`), 0644)).To(Succeed())
+		props, err := libjvm.NewManifest(ctx.Application.Path)
+		Expect(err).NotTo(HaveOccurred())
+
+		s := boot.NewSpringPerformance(dc, ctx.Application.Path, props, aotEnabled, performanceType, "", true, "")
+		s.Executor = executor
+
+		layer, err := ctx.Layers.Layer("test-layer")
+		Expect(err).NotTo(HaveOccurred())
+
+		_, err = s.Contribute(layer)
+		Expect(err).NotTo(HaveOccurred())
+
+		var normalizedModTime = time.Date(1980, time.January, 1, 0, 0, 1, 0, time.UTC)
+
+		for _, path := range []string{"META-INF", "BOOT-INF", filepath.Join("BOOT-INF", "lib")} {
+			fi, err := os.Stat(filepath.Join(ctx.Application.Path, path))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(fi.ModTime().UTC()).To(Equal(normalizedModTime), path)
+		}
+
+		// the application directory itself is left alone: on some platforms it is
+		// a mount point that the build user does not own and cannot touch
+		fi, err := os.Stat(ctx.Application.Path)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(fi.ModTime().UTC()).NotTo(Equal(normalizedModTime))
+	})
+
 	it("contributes user-provided JAVA_TOOL_OPTIONS to training run", func() {
 		Expect(os.Setenv("JAVA_TOOL_OPTIONS", "default-opt")).To(Succeed())
 		aotEnabled = false
 		performanceType = boot.CdsAotCache
 		dc := libpak.DependencyCache{CachePath: "testdata"}
-		executor.On("Execute", mock.Anything).
-			Return(nil).
-			Run(func(args mock.Arguments) {
-				execution := args.Get(0).(effect.Execution)
-				if slices.Contains(execution.Args, "-version") && execution.Stderr != nil {
-					_, err := io.WriteString(execution.Stderr, javaVersion21Output)
-					Expect(err).NotTo(HaveOccurred())
-				}
-			}).Return(nil)
+		executor.On("Execute", mock.Anything).Return(nil).Run(mockExecute)
 
 		Expect(os.WriteFile(filepath.Join(ctx.Application.Path, "META-INF", "MANIFEST.MF"), []byte(`
 Spring-Boot-Version: 3.3.1
@@ -277,15 +315,7 @@ Spring-Boot-Lib: BOOT-INF/lib
 		aotEnabled = true
 		performanceType = boot.CdsAotCache
 		dc := libpak.DependencyCache{CachePath: "testdata"}
-		executor.On("Execute", mock.Anything).
-			Return(nil).
-			Run(func(args mock.Arguments) {
-				execution := args.Get(0).(effect.Execution)
-				if slices.Contains(execution.Args, "-version") && execution.Stderr != nil {
-					_, err := io.WriteString(execution.Stderr, javaVersion21Output)
-					Expect(err).NotTo(HaveOccurred())
-				}
-			}).Return(nil)
+		executor.On("Execute", mock.Anything).Return(nil).Run(mockExecute)
 
 		Expect(os.WriteFile(filepath.Join(ctx.Application.Path, "META-INF", "MANIFEST.MF"), []byte(`
 	Spring-Boot-Version: 3.3.1
@@ -335,15 +365,7 @@ Spring-Boot-Lib: BOOT-INF/lib
 		aotEnabled = true
 		performanceType = boot.CdsAotCache
 		dc := libpak.DependencyCache{CachePath: "testdata"}
-		executor.On("Execute", mock.Anything).
-			Return(nil).
-			Run(func(args mock.Arguments) {
-				execution := args.Get(0).(effect.Execution)
-				if slices.Contains(execution.Args, "-version") && execution.Stderr != nil {
-					_, err := io.WriteString(execution.Stderr, javaVersion21Output)
-					Expect(err).NotTo(HaveOccurred())
-				}
-			}).Return(nil)
+		executor.On("Execute", mock.Anything).Return(nil).Run(mockExecute)
 
 		Expect(os.WriteFile(filepath.Join(ctx.Application.Path, "META-INF", "MANIFEST.MF"), []byte(`
 Spring-Boot-Version: 3.3.1


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->

Ran into #590 when attempting to build with kpack when setting `BP_JVM_AOTCACHE_ENABLED`.

I believe the discrepancy comes from [utimensat](https://www.man7.org/linux/man-pages/man2/utimensat.2.html), the system call made as part of `os.Chtimes`, requiring ownership of a file rather than write permissions when provided arguments.
https://cs.opensource.google/go/go/+/refs/tags/go1.26.6:src/os/file_posix.go;l=180
```go
// os/file_posix.go
func Chtimes(name string, atime time.Time, mtime time.Time) error {
	utimes := chtimesUtimes(atime, mtime)
	if e := syscall.UtimesNano(fixLongPath(name), utimes[0:]); e != nil {
```
https://cs.opensource.google/go/go/+/go1.26.6:src/syscall/syscall_linux.go;l=347
```go
// syscall/syscall_linux.go
func UtimesNano(path string, ts []Timespec) (err error) {
	return utimensat(_AT_FDCWD, path, (*[2]Timespec)(unsafe.Pointer(&ts[0])), 0)
```
This matches with the error message being `operation not permitted` (`EPERM`).
From what I see for my kpack builds, the build user owns all of the files in the `workspace/` but not the directory itself.

I can't see any reason to chtimes the `workspace/` itself so I added a test to make sure it's not, which uncovered another issue: `reZip` is set to `true` so `AppPath` in the tests is deleted and never recreated, carrying a bad state into subsequent tests. The existing check failed silently as it chtimes the test's working directory instead. Subsequently changed the walk to use the full path in the case that the working dir =/= `AppPath`, and updated the tests so the mocked executor recreates `AppDir`.

Fixes #590

## Use Cases
Enabling `BP_JVM_AOTCACHE_ENABLED`/`BP_JVM_CDS_ENABLED` for kpack builds.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
