### PR TITLE
fix: add support for BP_UNPACK_LAYOUT_ONLY

### DIFF
--- a/boot/detect.go
+++ b/boot/detect.go
@@ -63,7 +63,7 @@ func (d Detect) Detect(context libcnb.DetectContext) (libcnb.DetectResult, error
 		return libcnb.DetectResult{}, fmt.Errorf("unable to create configuration resolver\n%w", err)
 	}
 
-	if sherpa.ResolveBool("BP_JVM_CDS_ENABLED") || sherpa.ResolveBool("BP_JVM_AOTCACHE_ENABLED") {
+	if sherpa.ResolveBool("BP_JVM_CDS_ENABLED") || sherpa.ResolveBool("BP_JVM_AOTCACHE_ENABLED") || sherpa.ResolveBool("BP_UNPACK_LAYOUT_ONLY") {
 
 		result = libcnb.DetectResult{
 			Pass: true,
@@ -75,7 +75,8 @@ func (d Detect) Detect(context libcnb.DetectContext) (libcnb.DetectResult, error
 					Requires: []libcnb.BuildPlanRequire{
 						{Name: PlanEntryJVMApplication},
 						{Name: PlanEntrySpringBoot},
-						// Require a JRE at build time to perform CdsAotCache training run
+						// Require a JRE at build time to perform the CdsAotCache training run,
+						// and to run `-Djarmode=tools ... extract` for BP_UNPACK_LAYOUT_ONLY
 						{Name: PlanEntryJRE, Metadata: map[string]interface{}{"build": true}},
 					},
 				},

--- a/boot/detect_test.go
+++ b/boot/detect_test.go
@@ -36,6 +36,12 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 		detect boot.Detect
 	)
 
+	it.After(func() {
+		Expect(os.Unsetenv("BP_JVM_CDS_ENABLED")).To(Succeed())
+		Expect(os.Unsetenv("BP_JVM_AOTCACHE_ENABLED")).To(Succeed())
+		Expect(os.Unsetenv("BP_UNPACK_LAYOUT_ONLY")).To(Succeed())
+	})
+
 	nativeResult := libcnb.DetectResult{
 		Pass: true,
 		Plans: []libcnb.BuildPlan{
@@ -77,7 +83,8 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 				Requires: []libcnb.BuildPlanRequire{
 					{Name: "jvm-application"},
 					{Name: "spring-boot"},
-					// Require a JRE at build time to perform CdsAotCache training run
+					// Require a JRE at build time to perform the CdsAotCache training run,
+					// and to run `-Djarmode=tools ... extract` for BP_UNPACK_LAYOUT_ONLY
 					{Name: "jre", Metadata: map[string]interface{}{"build": true}},
 				},
 			},
@@ -146,6 +153,17 @@ Spring-Boot-Native-Processed: true
 		Expect(os.RemoveAll(filepath.Join(ctx.Application.Path, "META-INF"))).To(Succeed())
 
 		Expect(os.Setenv("BP_JVM_AOTCACHE_ENABLED", "true")).To(Succeed())
+		Expect(detect.Detect(ctx)).To(Equal(performanceResult))
+
+	})
+
+	it("using BP_UNPACK_LAYOUT_ONLY", func() {
+
+		Expect(os.RemoveAll(filepath.Join(ctx.Application.Path, "META-INF"))).To(Succeed())
+
+		// the extract layout only mode runs `java -Djarmode=tools ... extract` at build
+		// time, so it needs a build time JRE just like the training run does
+		Expect(os.Setenv("BP_UNPACK_LAYOUT_ONLY", "true")).To(Succeed())
 		Expect(detect.Detect(ctx)).To(Equal(performanceResult))
 
 	})


### PR DESCRIPTION
- Ensure `BP_UNPACK_LAYOUT_ONLY` is recognized during detection.
- Require JRE at build time for extract-only mode.
- Add tests for extract-only functionality.

<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
BP_UNPACK_LAYOUT_ONLY was broken, no JRE was provided so it just failed at runtime...

## Checklist
<!-- Please confirm the following -->
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [X] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [X] I have added an integration test, if necessary.
* [X] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [X] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
